### PR TITLE
docs: fix typos across README, CSS, and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/usnistgov/WIPP-Registry-k8s
 
 [NIST Software Disclaimer](https://www.nist.gov/disclaimer)
 
-Note: The XML-based schemas provided with the WIPP Registry do not represent “standard” metadata representations and are specifically release as “as is,” and as such the National Institute of Standards and Technology (NIST) makes no warrant of any kind on the correctness or accuracy of the content of the schemas, nor the fitness of the schemas for any purpose and accepts any liability or responsibility for the consequences of the schemas use or misuse by anyone. 
+Note: The XML-based schemas provided with the WIPP Registry do not represent “standard” metadata representations and are specifically released as “as is,” and as such the National Institute of Standards and Technology (NIST) makes no warrant of any kind on the correctness or accuracy of the content of the schemas, nor the fitness of the schemas for any purpose and accepts any liability or responsibility for the consequences of the schemas use or misuse by anyone. 
 
 
 ## Known Issues

--- a/static/css/extra.css
+++ b/static/css/extra.css
@@ -1,4 +1,4 @@
-/* Bootstrap overide */
+/* Bootstrap override */
 .btn.btn-primary {
     background-color: #007ac1 !important;
     border-color: #565656;
@@ -62,10 +62,10 @@
     visibility: hidden;
     height: 0em;
 }
-/* End Bootstrap overide */
+/* End Bootstrap override */
 
-/* Fontawesome overide */
+/* Fontawesome override */
 .fas span {
     font-family: 'Source Sans Pro', sans-serif !important;
 }
-/* End fontawesome overide */
+/* End fontawesome override */

--- a/templates/nmrr_home/tiles.html
+++ b/templates/nmrr_home/tiles.html
@@ -2,7 +2,7 @@
 <script src="{% static 'js/tiles.js' %}"></script>
 
 {% if tiles|length > 0 %}
-    <h2 id="available-options">Resources Type</h2>
+    <h2 id="available-options">Resource Types</h2>
     {% for tile in tiles %}
     <div class="tile">
         <div class="icon">


### PR DESCRIPTION
## Summary

Fix 5 typos across 3 files:

- **README.md**: "specifically release as" → "specifically released as" (missing past tense)
- **static/css/extra.css**: "overide" → "override" (3 instances in CSS section comments)
- **templates/nmrr_home/tiles.html**: "Resources Type" → "Resource Types" (plural/singular agreement in heading)

No functional changes — documentation and comments only.